### PR TITLE
Patch tab wrong behavior

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -114,7 +114,7 @@ input.addEventListener("keyup", function() {
     }
 });
 
-input.addEventListener("keypress", function (event) {
+input.addEventListener("keydown", function (event) {
     // Tabulation
     if (event.keyCode === 9) {
         event.preventDefault();


### PR DESCRIPTION
When tab was press it still had the normal behavior and not writing 4 space cause the event was wrong it must be on keydown not on keypress 